### PR TITLE
[어드민] -  로그인 페이지 및 기초 OAuth 2.0 추가

### DIFF
--- a/src/main/java/com/leedae/boardandadmin/config/SecurityConfig.java
+++ b/src/main/java/com/leedae/boardandadmin/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .formLogin(withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"))
+                .oauth2Login(withDefaults())
                 .build();
     }
 

--- a/src/main/resources/templates/layouts/layout-header.html
+++ b/src/main/resources/templates/layouts/layout-header.html
@@ -133,6 +133,22 @@
         </div>
       </li>
       <!-- */-->
+
+<!--   로그인 버튼   -->
+      <li class="nav-item">
+        <a id="login" class="nav-link" href="#" role="button">
+          <i class="fas fa-sign-in-alt"></i>
+        </a>
+      </li>
+
+      <!--   로그아웃 버튼   -->
+      <li class="nav-item">
+        <a id="logout" class="nav-link" href="#" role="button">
+          <i class="fas fa-sign-out-alt"></i>
+        </a>
+      </li>
+
+
       <!--/* 전체 화면 토글 버튼 */-->
       <li class="nav-item">
         <a class="nav-link" data-widget="fullscreen" href="#" role="button">

--- a/src/main/resources/templates/layouts/layout-header.th.xml
+++ b/src/main/resources/templates/layouts/layout-header.th.xml
@@ -3,4 +3,6 @@
 <thlogic>
     <attr sel="#header-nav-home" th:href="@{/}" th:text="'Home'" />
     <attr sel="#header-nav-admin-members" th:href="@{/admin/members}" th:text="'Member'" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/oauth2/authorization/kakao}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>


### PR DESCRIPTION
This closes #18 

This pull request includes changes to enhance the security configuration and update the layout header to support OAuth2 login and logout functionality. The most important changes are as follows:

Security Improvements:

* [`src/main/java/com/leedae/boardandadmin/config/SecurityConfig.java`](diffhunk://#diff-ed16a767d62092c3a362f59d40214bbd6f0e26c09bfcd909f744aa91063cd343R24): Added OAuth2 login configuration to the security filter chain.

Layout Enhancements:

* [`src/main/resources/templates/layouts/layout-header.html`](diffhunk://#diff-eec2a1a8d21757e5a6cc753ca0b95c583728b8ab597a81cc1f386266ca651d64R136-R151): Added login and logout buttons to the navigation bar.
* [`src/main/resources/templates/layouts/layout-header.th.xml`](diffhunk://#diff-6faceb129b795e2df42ea0273e725b1ce9ba9081af1806adc0e19825f86927b6R6-R7): Updated the header to conditionally display login and logout links based on the user's authentication status.