### PR TITLE
[어드민] 댓글 관리 페이지 테스트 정의

### DIFF
--- a/src/main/java/com/leedae/boardandadmin/config/BeanConfig.java
+++ b/src/main/java/com/leedae/boardandadmin/config/BeanConfig.java
@@ -1,0 +1,16 @@
+package com.leedae.boardandadmin.config;
+
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BeanConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/leedae/boardandadmin/dto/ArticleDto.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/ArticleDto.java
@@ -1,0 +1,23 @@
+package com.leedae.boardandadmin.dto;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record ArticleDto(
+        Long id,
+        UserAccountDto userAccount,
+        String title,
+        String content,
+        Set<String> hahstags,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static  ArticleDto of(Long id, UserAccountDto userAccount, String title, String content, Set<String> hahstags, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleDto(id, userAccount, title, content, hahstags, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+
+}

--- a/src/main/java/com/leedae/boardandadmin/dto/properties/ProjectProperties.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/properties/ProjectProperties.java
@@ -1,0 +1,18 @@
+package com.leedae.boardandadmin.dto.properties;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 어드민 프로젝트 전용 프로퍼티
+ * @param board 게시판 관련 프로퍼티
+ */
+@ConfigurationProperties("project")
+public record ProjectProperties(Board board) {
+
+    /**
+     * 게시판 관련 프로퍼티
+     * @param url 게시판 서비스 호스트명
+     */
+    public record Board(String url){}
+}

--- a/src/main/java/com/leedae/boardandadmin/dto/response/ArticleClientResponse.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/response/ArticleClientResponse.java
@@ -1,0 +1,36 @@
+package com.leedae.boardandadmin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.leedae.boardandadmin.dto.ArticleDto;
+
+import java.util.List;
+
+public record ArticleClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+    public static ArticleClientResponse empty(){
+        return new ArticleClientResponse(
+                new Embedded(List.of()),
+                new Page(1,0,1,0)
+        );
+    }
+
+    public static ArticleClientResponse of(List<ArticleDto> articles){
+        return new ArticleClientResponse(
+                new Embedded(articles),
+                new Page(articles.size(), articles.size(),1,0)
+        );
+    }
+
+    public List<ArticleDto> articles(){ return this.embedded().articles(); }
+
+    public record Embedded(@JsonProperty("articles") List<ArticleDto> articles){}
+
+    public record Page(
+            int size,
+            long totalElement,
+            int totalPage,
+            int number
+    ){}
+}

--- a/src/main/java/com/leedae/boardandadmin/service/ArticleManagementService.java
+++ b/src/main/java/com/leedae/boardandadmin/service/ArticleManagementService.java
@@ -1,0 +1,26 @@
+package com.leedae.boardandadmin.service;
+
+import com.leedae.boardandadmin.dto.ArticleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleManagementService {
+
+    public List<ArticleDto> getArticles(){
+        return List.of();
+    }
+
+    public ArticleDto getArticle(Long articleId){
+        return null;
+    }
+
+    public void deleteArticle(Long articleId){
+
+    }
+
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ logging:
     com.leedae.boardandadmin: debug
     org.springframework.web.servlet: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+    org.springframework.web.client.RestTemplate: debug
 
 server.port: 8081
 
@@ -58,6 +59,8 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
+project.board.url: http://localhost:8080
 
 
 ---

--- a/src/test/java/com/leedae/boardandadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/leedae/boardandadmin/controller/ArticleManagementControllerTest.java
@@ -1,24 +1,38 @@
 package com.leedae.boardandadmin.controller;
 
 import com.leedae.boardandadmin.config.SecurityConfig;
+import com.leedae.boardandadmin.domain.constant.RoleType;
+import com.leedae.boardandadmin.dto.ArticleDto;
+import com.leedae.boardandadmin.dto.UserAccountDto;
+import com.leedae.boardandadmin.service.ArticleManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 게시글 관리")
+@DisplayName("컨트롤러 - 게시글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
 
     private final MockMvc mvc;
+
+    @MockBean private ArticleManagementService articleManagementService;
 
     public ArticleManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -28,12 +42,79 @@ class ArticleManagementControllerTest {
     @Test
     void givenNothing_whenRequestingArticleManagementView_thenReturnsArticleManagementView() throws Exception {
         //given
+        given(articleManagementService.getArticles()).willReturn(List.of());
 
         //when & then
         mvc.perform(get("/management/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/articles"));
+                .andExpect(view().name("management/articles"))
+                .andExpect(model().attribute("articles",List.of()));
+        then(articleManagementService).should().getArticles();
 
     }
+
+    @DisplayName("[data][GET] 게시글 1개 - 정상 호출")
+    @Test
+    void givenArticleId_whenRequestingArticle_thenReturnsArticle() throws Exception {
+        //Given
+        Long articleId = 1L;
+        ArticleDto articleDto = createArticleDto("title","content");
+        given(articleManagementService.getArticle(articleId)).willReturn(articleDto);
+
+        // When & Then
+        mvc.perform(get("/management/articles/" + articleId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(articleId))
+                .andExpect(jsonPath("$.title").value("title"))
+                .andExpect(jsonPath("$.content").value("content"))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleDto.userAccount().nickname()));
+        then(articleManagementService).should().getArticle(articleId);
+
+    }
+
+    @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
+    @Test
+    void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagementView() throws Exception{
+        //Given
+        Long articleId = 1L;
+        willDoNothing().given(articleManagementService).deleteArticle(articleId);
+
+        // When & Then
+        mvc.perform(
+                post("/management/articles/" + articleId)
+                        .with(csrf())
+        )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/articles"))
+                .andExpect(redirectedUrl("/management/articles"));
+
+        then(articleManagementService).should().deleteArticle(articleId);
+    }
+
+    private ArticleDto createArticleDto(String title, String content) {
+        return ArticleDto.of(
+                1L,
+                createUserAccountDto(),
+                title,
+                content,
+                null, LocalDateTime.now(),
+                "Lee",
+                LocalDateTime.now(),
+                "Lee"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "leeTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "lee@gmai.com",
+                "leedae",
+                "leedaememo"
+        );
+    }
+
 }

--- a/src/test/java/com/leedae/boardandadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/leedae/boardandadmin/service/ArticleManagementServiceTest.java
@@ -1,0 +1,194 @@
+package com.leedae.boardandadmin.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leedae.boardandadmin.domain.constant.RoleType;
+import com.leedae.boardandadmin.dto.ArticleDto;
+import com.leedae.boardandadmin.dto.UserAccountDto;
+import com.leedae.boardandadmin.dto.properties.ProjectProperties;
+import com.leedae.boardandadmin.dto.response.ArticleClientResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+
+@ActiveProfiles("test")
+@DisplayName("비즈니스 로직 - 게시글 관리")
+class ArticleManagementServiceTest {
+
+    //restTemplate을 가져다가 이것을 모킹할 것인가 직접 가져다 쓸 것인가
+    //모킹해서 쓸 거면 외부 서비스가 장애가 생겨도 모킹 했기 때문에 우리 서비스에선 별 다른 영향이 없음.
+
+    //    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
+    @DisplayName("실제 API 호출 테스트")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+
+        private final ArticleManagementService sut;
+
+        @Autowired
+
+        public RealApiTest(ArticleManagementService sut) {
+            this.sut = sut;
+        }
+
+        @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
+        @Test
+        void given_when_then(){
+            // Given
+
+            // When
+            List<ArticleDto> result = sut.getArticles();
+
+            // Then
+            System.out.println(result.stream().findFirst());
+            assertThat(result).isNotNull();
+
+        }
+    }
+
+    @DisplayName("API mocking 테스트")
+    @EnableConfigurationProperties(ProjectProperties.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(ArticleManagementService.class)
+    @Nested //중첩 테스트
+    class RestTemplateTest {
+
+
+        private final ArticleManagementService sut;
+
+        private final ProjectProperties projectProperties; //url 직접 가져오기
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        @Autowired
+        public RestTemplateTest(
+                ArticleManagementService sut, ProjectProperties projectProperties,
+                MockRestServiceServer server, ObjectMapper mapper
+        ) {
+            this.sut = sut;
+            this.projectProperties = projectProperties;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+
+        @DisplayName("게시글 목록 API를 호출하면, 게시글들을 가져온다.")
+        @Test
+        void givenNothing_whenCallingArticlesApi_thenReturnsArticleList() throws JsonProcessingException {
+            //given
+            ArticleDto expectedArticle = createArticleDto("제목", "글");
+            ArticleClientResponse expectedResponse = ArticleClientResponse.of(List.of(expectedArticle));
+
+            //when
+            List<ArticleDto> result = sut.getArticles();
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles?size=10000"))
+                    .andRespond(MockRestResponseCreators.withSuccess(
+                            mapper.writeValueAsBytes(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            //then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
+                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("게시글 ID와 함께 게시글 API을 호출하면, 게시글을 가져온다.")        @Test
+        void givenNothing_whenCallingArticleApi_thenReturnsArticle() throws Exception {
+            //given
+            Long articleId = 1L;
+            ArticleDto expectedArticle = createArticleDto("게시판", "글");
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId))
+                    .andRespond(MockRestResponseCreators.withSuccess(
+                            mapper.writeValueAsBytes(expectedArticle),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            //when
+            ArticleDto result = sut.getArticle(articleId);
+
+            //then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
+                    .hasFieldOrPropertyWithValue("title", expectedArticle.title())
+                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("게시글 ID와 함께 게시글 삭제 API를 호출하면, 게시글을 삭제한다.")
+        @Test
+        void givenArticleId_whenCallingDeleteArticleApi_thenDeletesAnArticle() throws JsonProcessingException {
+            //given
+            Long articeId = 1L;
+            server
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articeId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+            //when
+            sut.deleteArticle(articeId);
+
+            //then
+            server.verify();
+        }
+
+
+    }
+
+    private ArticleDto createArticleDto(String title, String content) {
+        return ArticleDto.of(
+                1L,
+                createUserAccountDto(),
+                title,
+                content,
+                null,
+                LocalDateTime.now(),
+                "Lee",
+                LocalDateTime.now(),
+                "Lee"
+
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "leeTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "lee-test@gmail.com",
+                "lee-test",
+                "test memo"
+        );
+    }
+
+
+}


### PR DESCRIPTION
이 pr은 댓글 관리 페이지 기능을 구현하기 위한 비즈니스 로직과 컨트롤러의 테스트를 추가한다.
구현이 없으므로 테스트가 실패하는 상태.

This closes #20 