### PR TITLE
[어드민]  - 어드민 회원 테이블명 교체

### DIFF
--- a/src/main/java/com/leedae/boardandadmin/domain/AdminAccount.java
+++ b/src/main/java/com/leedae/boardandadmin/domain/AdminAccount.java
@@ -20,7 +20,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
 
     @Id
     @Column(length = 50)
@@ -37,9 +37,9 @@ public class UserAccount extends AuditingFields {
     @Setter private String memo;
 
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -51,13 +51,13 @@ public class UserAccount extends AuditingFields {
     }
 
 
-    public static UserAccount of(String userId, String userPassword,Set<RoleType> roletypes, String email, String nickname, String memo) {
-        return new UserAccount(userId, userPassword,roletypes, email, nickname, memo,null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roletypes, String email, String nickname, String memo) {
+        return new AdminAccount(userId, userPassword,roletypes, email, nickname, memo,null);
     }
 
 
-    public static UserAccount of(String userId, String userPassword,Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-        return new UserAccount(userId, userPassword,roleTypes, email, nickname, memo,createdBy);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+        return new AdminAccount(userId, userPassword,roleTypes, email, nickname, memo,createdBy);
     }
 
     public void addRoleType(RoleType roleType) {
@@ -75,7 +75,7 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object object) {
         if (this == object) return true;
-        if (!(object instanceof UserAccount that)) return false;
+        if (!(object instanceof AdminAccount that)) return false;
         return Objects.equals(getUserId(), that.getUserId());
     }
 

--- a/src/main/java/com/leedae/boardandadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/AdminAccountDto.java
@@ -1,0 +1,60 @@
+package com.leedae.boardandadmin.dto;
+
+
+import com.leedae.boardandadmin.domain.AdminAccount;
+import com.leedae.boardandadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo,
+                                     LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+
+        return AdminAccountDto.of(userId, userPassword,roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+
+    }
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+
+        return new AdminAccountDto(userId, userPassword,roleTypes, email, nickname, memo, null, null, null, null);
+
+    }
+
+    public static AdminAccountDto from(AdminAccount entity){
+
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity(){
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/leedae/boardandadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/UserAccountDto.java
@@ -1,7 +1,6 @@
 package com.leedae.boardandadmin.dto;
 
 
-import com.leedae.boardandadmin.domain.UserAccount;
 import com.leedae.boardandadmin.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -9,7 +8,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,42 +17,16 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy) {
 
-    public static UserAccountDto of(String userId, String userPassword,Set<RoleType> roleTypes, String email, String nickname, String memo,
+    public static UserAccountDto of(String userId,Set<RoleType> roleTypes, String email, String nickname, String memo,
                           LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
 
-        return UserAccountDto.of(userId, userPassword,roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
 
     }
-    public static UserAccountDto of(String userId, String userPassword,Set<RoleType> roleTypes, String email, String nickname, String memo) {
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
 
-        return new UserAccountDto(userId, userPassword,roleTypes, email, nickname, memo, null, null, null, null);
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, null, null, null, null);
 
     }
 
-    public static UserAccountDto from(UserAccount entity){
-
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity(){
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
-    }
 }

--- a/src/main/java/com/leedae/boardandadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/leedae/boardandadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.leedae.boardandadmin.dto.security;
 
 import com.leedae.boardandadmin.domain.constant.RoleType;
-import com.leedae.boardandadmin.dto.UserAccountDto;
+import com.leedae.boardandadmin.dto.AdminAccountDto;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -59,7 +59,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto){
+    public static BoardAdminPrincipal from(AdminAccountDto dto){
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -70,8 +70,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto(){
-        return UserAccountDto.of(
+    public AdminAccountDto toDto(){
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream().map(GrantedAuthority::getAuthority).map(RoleType::valueOf).collect(Collectors.toUnmodifiableSet()),

--- a/src/main/java/com/leedae/boardandadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/leedae/boardandadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.leedae.boardandadmin.repository;
+
+import com.leedae.boardandadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/src/main/java/com/leedae/boardandadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/leedae/boardandadmin/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.leedae.boardandadmin.repository;
-
-import com.leedae.boardandadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,7 @@
 
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
                                                                                                                                            ('lee', '{noop}asdf1234', 'ADMIN', 'lee', 'lee@mail.com', 'I am lee.', now(), 'lee', now(), 'lee'),
                                                                                                                                            ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'lee', now(), 'lee'),
                                                                                                                                            ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'lee', now(), 'lee'),

--- a/src/test/java/com/leedae/boardandadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/leedae/boardandadmin/controller/ArticleCommentManagementControllerTest.java
@@ -112,7 +112,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto(){
         return UserAccountDto.of(
                 "leeleeleeleeleeHero!!",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "lee@gmail.com",
                 "uno-test",

--- a/src/test/java/com/leedae/boardandadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/leedae/boardandadmin/controller/ArticleManagementControllerTest.java
@@ -109,7 +109,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "leeTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "lee@gmai.com",
                 "leedae",

--- a/src/test/java/com/leedae/boardandadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/leedae/boardandadmin/repository/JpaRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.leedae.boardandadmin.repository;
 
 
-import com.leedae.boardandadmin.domain.UserAccount;
+import com.leedae.boardandadmin.domain.AdminAccount;
 import com.leedae.boardandadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +18,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.*;
 
 @DisplayName("JPA 연결 테스트")
 @Import(JpaRepositoryTest.TestJpaConfig.class)
@@ -27,10 +25,10 @@ import static org.mockito.BDDMockito.*;
 class JpaRepositoryTest {
 
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
@@ -39,10 +37,10 @@ class JpaRepositoryTest {
         //given
 
         //when
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         //then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
@@ -51,15 +49,15 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccounts_whenUpdated_thenWorksFine(){
         //given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test","pw", Set.of(RoleType.DEVELOPER),null,null,null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test","pw", Set.of(RoleType.DEVELOPER),null,null,null);
 
 
         //when
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         //then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
         .isEqualTo(previousCount + 1);
     }
 
@@ -68,13 +66,13 @@ class JpaRepositoryTest {
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine(){
 
         //given
-        UserAccount userAccount = userAccountRepository.getReferenceById("lee");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleType(List.of(RoleType.USER,RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("lee");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleType(List.of(RoleType.USER,RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         //when
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         //then
         assertThat(updatedAccount)
@@ -87,16 +85,16 @@ class JpaRepositoryTest {
     void givenUserAccount_whenDeleting_thenWorksFine(){
 
         //given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("lee");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("lee");
 
 
         //when
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount-1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount-1);
 
 
 

--- a/src/test/java/com/leedae/boardandadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/leedae/boardandadmin/service/ArticleCommentManagementServiceTest.java
@@ -143,7 +143,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto(){
         return UserAccountDto.of(
                 "leeTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "lee@gmail.com",
                 "leetest",

--- a/src/test/java/com/leedae/boardandadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/leedae/boardandadmin/service/ArticleManagementServiceTest.java
@@ -182,7 +182,6 @@ class ArticleManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "leeTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "lee-test@gmail.com",
                 "lee-test",


### PR DESCRIPTION
이 pr은 `user_account` -> `admin_account`로 테이블명 변경 통신하려는 게시판 서비스의 회원 도메인명과 겹친다.
그러므로 테이블명을 변경하였음.

This closes #33 